### PR TITLE
Change hyperkube version to reflect v0.15.0

### DIFF
--- a/cluster/images/hyperkube/master.json
+++ b/cluster/images/hyperkube/master.json
@@ -7,7 +7,7 @@
   "containers":[
     {
       "name": "controller-manager",
-      "image": "gcr.io/google_containers/hyperkube:v0.14.1",
+      "image": "gcr.io/google_containers/hyperkube:v0.15.0",
       "command": [
               "/hyperkube",
               "controller-manager",
@@ -19,7 +19,7 @@
     },
     {
       "name": "apiserver",
-      "image": "gcr.io/google_containers/hyperkube:v0.14.1",
+      "image": "gcr.io/google_containers/hyperkube:v0.15.0",
       "command": [
               "/hyperkube",
               "apiserver",
@@ -32,7 +32,7 @@
     },
     {
       "name": "scheduler",
-      "image": "gcr.io/google_containers/hyperkube:v0.14.1",
+      "image": "gcr.io/google_containers/hyperkube:v0.15.0",
       "command": [
               "/hyperkube",
               "scheduler",


### PR DESCRIPTION
Changing the master.json file so as to reflect the new version of the of hyperkube.
It fixes an issue when trying to launch the command : 
docker run --net=host -d -v /var/run/docker.sock:/var/run/docker.sock  gcr.io/google_containers/hyperkube:v0.15.0 /hyperkube kubelet --api_servers=http://localhost:8080 --v=2 --address=0.0.0.0 --enable_server --hostname_override=127.0.0.1 --config=/etc/kubernetes/manifests